### PR TITLE
add route to CSP in _headers file

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,3 +1,4 @@
+/*
 Content-Security-Policy: default-src 'self'; 
 Content-Security-Policy: script-src 'self' 'nonce-CQk8c2NyaXB0IHNyYz0iLi9zY3JpcHRzLm1pbi5qcyI+PC9zY3JpcHQ+CgkJPHNjcmlwdCBzcmM9Ii4vZGlzY29yZFN0YXQubWluLmpzIiB0eXBlPSJtb2R1bGUiPjwvc2NyaXB0Pg=='; 
 Content-Security-Policy: style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; 


### PR DESCRIPTION
Like robots.txt, _headers requires you to specify the route for a specific HTTP header. In this case, this is a site-wide CSP and requires the all paths wildcard route as a result.

I hadn't noticed this in PRs #13, #12, or #11 so this fixes that issue.

This would be a handy thing to test in a preview deployment of some kind in Cloudflare Pages