### PR TITLE
any host will have caching headers now, unsafe-inline in default-src is req'd for dark reader because cloudflare

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,5 +1,6 @@
 /*
-Content-Security-Policy: default-src 'self' 'strict-dynamic' 'sha256-iGVRMz1vIPczK8yVNtIHOPgnR8vHWkk0uahMXmsPrEs=' 'sha256-qjg+14aJCOUUmQulGzkJ71Q/xZCM6z5SCL1p2QJOD0o=' https://fonts.googleapis.com https://fonts.gstatic.com https://api.lanyard.rest https://download.stigstille.uk https://stigstille.uk; 
+Cache-Control: max-age=31536000, public, immutable
+Content-Security-Policy: default-src 'self' 'unsafe-inline' 'strict-dynamic' 'sha256-iGVRMz1vIPczK8yVNtIHOPgnR8vHWkk0uahMXmsPrEs=' 'sha256-qjg+14aJCOUUmQulGzkJ71Q/xZCM6z5SCL1p2QJOD0o=' https://darkreader.org https://fonts.googleapis.com https://fonts.gstatic.com https://api.lanyard.rest https://download.stigstille.uk https://stigstille.uk; 
     script-src 'unsafe-inline' 'strict-dynamic' 'sha256-iGVRMz1vIPczK8yVNtIHOPgnR8vHWkk0uahMXmsPrEs=' 'sha256-qjg+14aJCOUUmQulGzkJ71Q/xZCM6z5SCL1p2QJOD0o=' https:; 
     script-src-elem 'unsafe-inline' 'strict-dynamic' 'sha256-iGVRMz1vIPczK8yVNtIHOPgnR8vHWkk0uahMXmsPrEs=' 'sha256-qjg+14aJCOUUmQulGzkJ71Q/xZCM6z5SCL1p2QJOD0o=' https:; 
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; 


### PR DESCRIPTION
info on immutable tag: https://www.keycdn.com/blog/cache-control-immutable